### PR TITLE
Create folder if it does not exist when running downloadGeneratorJar 

### DIFF
--- a/Software/MATLAB/app/system/+openapi/+internal/@Jars/downloadGeneratorJar.m
+++ b/Software/MATLAB/app/system/+openapi/+internal/@Jars/downloadGeneratorJar.m
@@ -37,6 +37,7 @@ function jarPath = downloadGeneratorJar(version, options)
         if options.verbose
             fprintf("Downloading: %s\n", jarURL)
         end
+        if ~isfolder(options.destinationDir); mkdir(options.destinationDir); end
         websave(jarPath, jarURL, options.weboptions);
     end
 end


### PR DESCRIPTION
I cloned the repository, and did not have the folder:
`~/matlab-openapi-generator/Software/MATLAB/lib/jar` and so the `setup` failed with the following error:

```
Error using websave
Unable to open output file:
'/Users/Eivind/Code/MATLAB/General/Repositories/mathworks-ref-arch/matlab-openapi-generator/Software/MATLAB/lib/jar/openapi-generator-cli-7.10.0.jar'
for writing. Common reasons include that the file exists and does not have write permission or the folder does not have write permissions.

Error in openapi.internal.Jars.downloadGeneratorJar (line 40)
        websave(jarPath, jarURL, options.weboptions);

Error in setup (line 62)
        jarPath = openapi.internal.Jars.downloadGeneratorJar(generatorVersion, verbose=options.verbose); %#ok<NASGU>
```